### PR TITLE
Add doc-comment to test README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ exclude = [ "target/*", "Cargo.lock" ]
 default = []
 no_std = []
 bench = []
+
+[dev-dependencies]
+doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,13 @@ extern crate std;
 #[cfg(feature = "bench")]
 extern crate test;
 
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
+
 use tables::charwidth as cw;
 pub use tables::UNICODE_VERSION;
 


### PR DESCRIPTION
Allows to keep in check the README file examples.