### PR TITLE
Update support for being built in rust-lang/rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,13 @@ according to Unicode Standard Annex #11 rules.
 
 exclude = [ "target/*", "Cargo.lock" ]
 
+[dependencies]
+std = { version = "1.0", package = "rustc-std-workspace-std", optional = true }
+core = { version = "1.0", package = "rustc-std-workspace-core", optional = true }
+compiler_builtins = { version = "0.1", optional = true }
+
 [features]
 default = []
 no_std = []
 bench = []
+rustc-dep-of-std = ['std', 'core', 'compiler_builtins']


### PR DESCRIPTION
This commit updates the support necessary for this crate to be built as
a dependency of `getopts` which is a dependency of the `test` crate
which is built in rust-lang/rust. This change will be required to land
rust-lang/rust#63637 where Rust's build system is being tweaked
slightly. This is intended to not have any impact on other users of this
crate and the `Cargo.toml` features here should only be used by Rust's
own build system.