### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,10 @@
 //! unicode-width = "0.1.5"
 //! ```
 
-#![deny(missing_docs, unsafe_code)]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
 #![doc(html_logo_url = "https://unicode-rs.github.io/unicode-rs_sm.png",
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
-
 #![cfg_attr(feature = "bench", feature(test))]
 #![no_std]
 


### PR DESCRIPTION
Unlike "deny", "forbid" cannot be overridden.  It easier to prove there
is no unsafe code in this crate this way.

Context: https://github.com/rust-secure-code/safety-dance

Closes #19