### PR TITLE
nostd: remove left-overs from `no_std` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ compiler_builtins = { version = "0.1", optional = true }
 
 [features]
 default = []
-no_std = []
 bench = []
 rustc-dep-of-std = ['std', 'core', 'compiler_builtins']
+
+# Legacy, now a no-op
+no_std = []

--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -422,8 +422,6 @@ pub const UNICODE_VERSION: (u8, u8, u8) = {unicode_version};
         module.write(
             """
 pub mod charwidth {
-    use core::option::Option::{self, None, Some};
-
     /// Returns the [UAX #11](https://www.unicode.org/reports/tr11/) based width of `c` by
     /// consulting a multi-level lookup table.
     /// If `is_cjk == true`, ambiguous width characters are treated as double width; otherwise,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@
 //!
 //! # features
 //!
-//! unicode-width supports a `no_std` feature. This eliminates dependence
-//! on std, and instead uses equivalent functions from core.
+//! unicode-width does not depend on `std`, so it can be used in crates
+//! with the `#![no_std]` attribute.
 //!
 //! # crates.io
 //!

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -15,8 +15,6 @@
 pub const UNICODE_VERSION: (u8, u8, u8) = (15, 1, 0);
 
 pub mod charwidth {
-    use core::option::Option::{self, None, Some};
-
     /// Returns the [UAX #11](https://www.unicode.org/reports/tr11/) based width of `c` by
     /// consulting a multi-level lookup table.
     /// If `is_cjk == true`, ambiguous width characters are treated as double width; otherwise,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,7 @@ use super::{UnicodeWidthChar, UnicodeWidthStr};
 #[cfg(feature = "bench")]
 use std::iter;
 #[cfg(feature = "bench")]
-use test::{self, Bencher};
+use test::Bencher;
 
 use std::prelude::v1::*;
 
@@ -140,8 +140,6 @@ fn test_emoji() {
 #[test]
 fn test_char() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('ｈ'), Some(2));
     assert_eq!('ｈ'.width_cjk(), Some(2));
@@ -156,8 +154,6 @@ fn test_char() {
 #[test]
 fn test_char2() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\x00'), Some(0));
     assert_eq!('\x00'.width_cjk(), Some(0));
@@ -187,8 +183,6 @@ fn test_char2() {
 #[test]
 fn unicode_12() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\u{1F971}'), Some(2));
 }
@@ -196,8 +190,6 @@ fn unicode_12() {
 #[test]
 fn test_default_ignorable() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\u{E0000}'), Some(0));
 
@@ -209,8 +201,6 @@ fn test_default_ignorable() {
 #[test]
 fn test_jamo() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\u{1100}'), Some(2));
     assert_eq!(UnicodeWidthChar::width('\u{A97C}'), Some(2));
@@ -225,8 +215,6 @@ fn test_jamo() {
 #[test]
 fn test_prepended_concatenation_marks() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\u{0600}'), Some(1));
     assert_eq!(UnicodeWidthChar::width('\u{070F}'), Some(1));
@@ -237,8 +225,6 @@ fn test_prepended_concatenation_marks() {
 #[test]
 fn test_interlinear_annotation_chars() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\u{FFF9}'), Some(1));
     assert_eq!(UnicodeWidthChar::width('\u{FFFA}'), Some(1));
@@ -248,8 +234,6 @@ fn test_interlinear_annotation_chars() {
 #[test]
 fn test_hieroglyph_format_controls() {
     use super::UnicodeWidthChar;
-    #[cfg(feature = "no_std")]
-    use core::option::Option::{None, Some};
 
     assert_eq!(UnicodeWidthChar::width('\u{13430}'), Some(1));
     assert_eq!(UnicodeWidthChar::width('\u{13436}'), Some(1));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -93,7 +93,7 @@ fn simple_width_match(c: char) -> Option<usize> {
         _ => UnicodeWidthChar::width(c),
     }
 }
-#[cfg(all(feature = "bench", not(feature = "no_std")))]
+#[cfg(feature = "bench")]
 #[bench]
 fn enwik8(b: &mut Bencher) {
     // To benchmark, download & unzip `enwik8` from https://data.deepai.org/enwik8.zip
@@ -101,7 +101,7 @@ fn enwik8(b: &mut Bencher) {
     let string = std::fs::read_to_string(data_path).unwrap_or_default();
     b.iter(|| test::black_box(UnicodeWidthStr::width(string.as_str())));
 }
-#[cfg(all(feature = "bench", not(feature = "no_std")))]
+#[cfg(feature = "bench")]
 #[bench]
 fn jawiki(b: &mut Bencher) {
     // To benchmark, download & extract `jawiki-20220501-pages-articles-multistream-index.txt` from


### PR DESCRIPTION
The `no_std` feature flag has been reworked in the past and is now basically the default. This PR removes some leftovers, fixes several warnings about redundant use-declarations, and updates the documentation.

None of this is critical, so feel free to cherry-pick individual pieces, or let me know how to rework them.

Note that I did not see any `rust-version` or MSVR annotations, so I could not test this with the base version. But I do not think the preludes changed much, so this should be fine.