### PR TITLE
adapt for rustc-dep-of-std build

### DIFF
--- a/src/tables.rs
+++ b/src/tables.rs
@@ -15,6 +15,8 @@
 pub const UNICODE_VERSION: (u8, u8, u8) = (15, 1, 0);
 
 pub mod charwidth {
+    use core::convert::TryFrom;
+
     /// Returns the [UAX #11](https://www.unicode.org/reports/tr11/) based width of `c` by
     /// consulting a multi-level lookup table.
     /// If `is_cjk == true`, ambiguous width characters are treated as double width; otherwise,


### PR DESCRIPTION
No functional changes intended.

Fixes an error when using the latest version of this crate as a dep-of-std:
```
error[E0599]: no function or associated item named `try_from` found for type `usize` in the current scope
```