### PR TITLE
include U+0000 in comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ fn single_char_width(c: char, is_cjk: bool) -> Option<usize> {
             // U+0020 to U+007F (exclusive) are single-width ASCII codepoints
             Some(1)
         } else {
-            // U+0001 to U+0020 (exclusive) are control codes
+            // U+0000 to U+0020 (exclusive) are control codes
             None
         }
     } else if c >= '\u{A0}' {


### PR DESCRIPTION
`\0` is control code as per
https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=\p{subhead=C0%20controls} and
https://github.com/unicode-rs/unicode-width/commit/4efb1803faa054f1bea3c0457275ad3c8610170b#diff-387ba8e3571da5c65e19e7cd5c7ee2e22177aeff5660ea2e51e2ff7b881af556L680