### PR TITLE
Treat newlines as width 0 in the 0.1 stream, publish 0.1.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 authors = [
     "kwantam <kwantam@gmail.com>",
     "Manish Goregaokar <manishsmail@gmail.com>",

--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -1281,7 +1281,10 @@ fn width_in_str{cjk_lo}(c: char, mut next_info: WidthInfo) -> (i8, WidthInfo) {{
     s += """
     if c <= '\\u{A0}' {
         match c {
-            '\\n' => (1, WidthInfo::LINE_FEED),
+            // According to the spec, LF should be width 1, which is how it is often rendered when it is forced to have a single-line rendering
+            // However, this makes it harder to use this crate to calculate line breaks, and breaks assumptions of downstream crates.
+            // https://github.com/unicode-rs/unicode-width/issues/60
+            '\\n' => (0, WidthInfo::LINE_FEED),
             '\\r' if next_info == WidthInfo::LINE_FEED => (0, WidthInfo::DEFAULT),
             _ => (1, WidthInfo::DEFAULT),
         }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -215,7 +215,10 @@ fn width_in_str(c: char, mut next_info: WidthInfo) -> (i8, WidthInfo) {
     }
     if c <= '\u{A0}' {
         match c {
-            '\n' => (1, WidthInfo::LINE_FEED),
+            // According to the spec, LF should be width 1, which is how it is often rendered when it is forced to have a single-line rendering
+            // However, this makes it harder to use this crate to calculate line breaks, and breaks assumptions of downstream crates.
+            // https://github.com/unicode-rs/unicode-width/issues/60
+            '\n' => (0, WidthInfo::LINE_FEED),
             '\r' if next_info == WidthInfo::LINE_FEED => (0, WidthInfo::DEFAULT),
             _ => (1, WidthInfo::DEFAULT),
         }
@@ -507,7 +510,10 @@ fn width_in_str_cjk(c: char, mut next_info: WidthInfo) -> (i8, WidthInfo) {
     }
     if c <= '\u{A0}' {
         match c {
-            '\n' => (1, WidthInfo::LINE_FEED),
+            // According to the spec, LF should be width 1, which is how it is often rendered when it is forced to have a single-line rendering
+            // However, this makes it harder to use this crate to calculate line breaks, and breaks assumptions of downstream crates.
+            // https://github.com/unicode-rs/unicode-width/issues/60
+            '\n' => (0, WidthInfo::LINE_FEED),
             '\r' if next_info == WidthInfo::LINE_FEED => (0, WidthInfo::DEFAULT),
             _ => (1, WidthInfo::DEFAULT),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -214,18 +214,23 @@ fn test_control_line_break() {
     assert_width!('\r', None, None);
     assert_width!('\n', None, None);
     assert_width!("\r", 1, 1);
-    assert_width!("\n", 1, 1);
-    assert_width!("\r\n", 1, 1);
+    // This is 0 due to #60
+    assert_width!("\n", 0, 0);
+    assert_width!("\r\n", 0, 0);
     assert_width!("\0", 1, 1);
-    assert_width!("1\t2\r\n3\u{85}4", 7, 7);
-    assert_width!("\r\u{FE0F}\n", 2, 2);
-    assert_width!("\r\u{200D}\n", 2, 2);
+    assert_width!("1\t2\r\n3\u{85}4", 6, 6);
+    assert_width!("\r\u{FE0F}\n", 1, 1);
+    assert_width!("\r\u{200D}\n", 1, 1);
 }
 
 #[test]
 fn char_str_consistent() {
     let mut s = String::with_capacity(4);
     for c in '\0'..=char::MAX {
+        // Newlines are special cased (#60)
+        if c == '\n' {
+            continue;
+        }
         s.clear();
         s.push(c);
         assert_eq!(c.width().unwrap_or(1), s.width());
@@ -418,6 +423,10 @@ fn test_khmer_coeng() {
             assert_width!(format!("\u{17D2}{c}"), 0, 0);
             assert_width!(format!("\u{17D2}\u{200D}\u{200D}{c}"), 0, 0);
         } else {
+            // Newlines are special cased (#60)
+            if c == '\n' {
+                continue;
+            }
             assert_width!(
                 format!("\u{17D2}{c}"),
                 c.width().unwrap_or(1),
@@ -586,6 +595,11 @@ fn emoji_test_file() {
             assert_width!(emoji, 2, 2);
         }
     }
+}
+
+#[test]
+fn test_newline_zero_issue_60() {
+    assert_width!("a\na", 2, 2);
 }
 
 // Test traits are unsealed


### PR DESCRIPTION
Fixes https://github.com/unicode-rs/unicode-width/issues/60 for the 0.1 stream. We may undo this in 0.2.


Fixes https://github.com/unicode-rs/unicode-width/issues/66