### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,11 @@ exclude = ["/.github/*"]
 [dependencies]
 std = { version = "1.0", package = "rustc-std-workspace-std", optional = true }
 core = { version = "1.0", package = "rustc-std-workspace-core", optional = true }
-compiler_builtins = { version = "0.1", optional = true }
 
 [features]
 cjk = []
 default = ["cjk"]
-rustc-dep-of-std = ['std', 'core', 'compiler_builtins']
+rustc-dep-of-std = ['std', 'core']
 
 # Legacy, now a no-op
 no_std = []


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993