### PR TITLE
Exclude development scripts from published packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,16 @@ according to Unicode Standard Annex #11 rules.
 edition = "2021"
 rust-version = "1.66"
 
-exclude = ["/.github/*"]
+include = [
+    "COPYRIGHT", 
+    "LICENSE-MIT", 
+    "LICENSE-APACHE", 
+    "README.md", 
+    "CARGO.toml", 
+    "src/**/*.rs", 
+    "benches/**/*.rs", 
+    "tests/**/*.rs",
+]
 
 [dependencies]
 std = { version = "1.0", package = "rustc-std-workspace-std", optional = true }


### PR DESCRIPTION
During a dependency review we noticed that the unicode-width crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.