### PR TITLE
Support `char` iter width

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -1556,16 +1556,15 @@ fn width_in_str{cjk_lo}(c: char, mut next_info: WidthInfo) -> (i8, WidthInfo) {{
 }}
 
 {cfg}#[inline]
-pub fn str_width{cjk_lo}(s: &str) -> usize {{
-    s.chars()
-        .rfold(
-            (0, WidthInfo::DEFAULT),
-            |(sum, next_info), c| -> (usize, WidthInfo) {{
-                let (add, info) = width_in_str{cjk_lo}(c, next_info);
-                (sum.wrapping_add_signed(isize::from(add)), info)
-            }},
-        )
-        .0
+pub fn str_width<S: DoubleEndedIterator<Item = char>>{cjk_lo}(s: S) -> usize {{
+    s.rfold(
+        (0, WidthInfo::DEFAULT),
+        |(sum, next_info), c| -> (usize, WidthInfo) {{
+            let (add, info) = width_in_str{cjk_lo}(c, next_info);
+            (sum.wrapping_add_signed(isize::from(add)), info)
+        }},
+    )
+    .0
 }}
 """
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,12 +248,23 @@ pub trait UnicodeWidthStr: private::Sealed {
 impl UnicodeWidthStr for str {
     #[inline]
     fn width(&self) -> usize {
-        tables::str_width(self)
+        tables::str_width(self.chars())
     }
 
     #[cfg(feature = "cjk")]
     #[inline]
     fn width_cjk(&self) -> usize {
-        tables::str_width_cjk(self)
+        tables::str_width_cjk(self.chars())
     }
+}
+
+/// Like [`UnicodeWidthStr::width`] but for iterators over [`char`].
+pub fn char_iter_width<S: DoubleEndedIterator<Item = char>>(s: S) -> usize {
+    tables::str_width(s)
+}
+
+/// Like [`UnicodeWidthStr::width_cjk`] but for iterators over [`char`].
+#[cfg(feature = "cjk")]
+pub fn char_iter_width_cjk<S: DoubleEndedIterator<Item = char>>(s: S) -> usize {
+    tables::str_width_cjk(s)
 }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -462,16 +462,15 @@ fn width_in_str(c: char, mut next_info: WidthInfo) -> (i8, WidthInfo) {
 }
 
 #[inline]
-pub fn str_width(s: &str) -> usize {
-    s.chars()
-        .rfold(
-            (0, WidthInfo::DEFAULT),
-            |(sum, next_info), c| -> (usize, WidthInfo) {
-                let (add, info) = width_in_str(c, next_info);
-                (sum.wrapping_add_signed(isize::from(add)), info)
-            },
-        )
-        .0
+pub fn str_width<S: DoubleEndedIterator<Item = char>>(s: S) -> usize {
+    s.rfold(
+        (0, WidthInfo::DEFAULT),
+        |(sum, next_info), c| -> (usize, WidthInfo) {
+            let (add, info) = width_in_str(c, next_info);
+            (sum.wrapping_add_signed(isize::from(add)), info)
+        },
+    )
+    .0
 }
 
 /// Returns the [UAX #11](https://www.unicode.org/reports/tr11/) based width of `c` by
@@ -783,16 +782,15 @@ fn width_in_str_cjk(c: char, mut next_info: WidthInfo) -> (i8, WidthInfo) {
 
 #[cfg(feature = "cjk")]
 #[inline]
-pub fn str_width_cjk(s: &str) -> usize {
-    s.chars()
-        .rfold(
-            (0, WidthInfo::DEFAULT),
-            |(sum, next_info), c| -> (usize, WidthInfo) {
-                let (add, info) = width_in_str_cjk(c, next_info);
-                (sum.wrapping_add_signed(isize::from(add)), info)
-            },
-        )
-        .0
+pub fn str_width_cjk<S: DoubleEndedIterator<Item = char>>(s: S) -> usize {
+    s.rfold(
+        (0, WidthInfo::DEFAULT),
+        |(sum, next_info), c| -> (usize, WidthInfo) {
+            let (add, info) = width_in_str_cjk(c, next_info);
+            (sum.wrapping_add_signed(isize::from(add)), info)
+        },
+    )
+    .0
 }
 
 /// Whether this character is a zero-width character with

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,7 +13,7 @@ use std::{
     io::{BufRead, BufReader},
 };
 
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::{char_iter_width, UnicodeWidthChar, UnicodeWidthStr};
 
 macro_rules! assert_width {
     ($s:expr, $nocjk:expr, $cjk:expr $(,)?) => {{
@@ -647,6 +647,11 @@ fn test_vs1_vs2_vs3() {
             );
         }
     }
+}
+
+#[test]
+fn test_char_iter() {
+    assert_eq!(char_iter_width(['a', 'b', '🔬'].into_iter()), 4)
 }
 
 // Test traits are unsealed


### PR DESCRIPTION
Add free functions for computing the width of iterators over `char`. The semantics are the same as if the chars were combined into a string.

This only works with `DoubleEndedIterator`s, because internally `rfold` is used, which is not available on arbitrary iterators.

Closes #82

Being able to use plain `Iterator` instead of `DoubleEndedIterator` might require quite significant internal changes, so I haven't attempted it.

So far, there is only one minimal test for the new functionality.