### PR TITLE
feat: add opt-in terminal feature for ambiguous-width ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ core = { version = "1.0", package = "rustc-std-workspace-core", optional = true 
 [features]
 cjk = []
 default = ["cjk"]
+# Terminal-emulator semantics: treat Enclosed Alphanumerics, Dingbat circled
+# digits, and circled numbers on black square as 2 columns even outside CJK
+# contexts. Most terminal emulators render these at double width regardless
+# of locale, so TUI consumers (e.g. ratatui) should opt in to match the
+# painted glyphs.
+terminal = []
 rustc-dep-of-std = ['std', 'core']
 
 # Legacy, now a no-op

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -21,11 +21,34 @@ use crate::width_info::WidthInfo;
 
 #[inline]
 fn lookup_width_generic<const IS_CJK: bool>(c: char) -> (u8, WidthInfo) {
+    #[cfg(feature = "terminal")]
+    if let Some(w) = terminal_width(c) {
+        return (w, WidthInfo::DEFAULT);
+    }
     #[cfg(feature = "cjk")]
     if IS_CJK {
         return lookup_width_cjk(c);
     }
     lookup_width(c)
+}
+
+/// Enclosed Alphanumerics (U+2460-U+24FF), Dingbat Circled Digits
+/// (U+2776-U+2793), and Circled Numbers on Black Square (U+3248-U+324F)
+/// have East Asian Width "Ambiguous", but terminal emulators render them
+/// as 2 columns in both CJK and non-CJK contexts. With the `terminal`
+/// feature enabled, report 2 so TUI consumers (e.g. ratatui) place them
+/// in two cells, matching the painted glyph.
+#[cfg(feature = "terminal")]
+#[inline]
+fn terminal_width(c: char) -> Option<u8> {
+    if matches!(
+        c,
+        '\u{2460}'..='\u{24FF}' | '\u{2776}'..='\u{2793}' | '\u{3248}'..='\u{324F}'
+    ) {
+        Some(2)
+    } else {
+        None
+    }
 }
 
 /// Returns the [UAX #11](https://www.unicode.org/reports/tr11/) based width of `c`, or

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -599,9 +599,22 @@ fn emoji_test_file() {
 
 #[test]
 fn ambiguous_line_break() {
-    assert_width!("\u{24EA}", 1, 2);
-    assert_width!("\u{2616}", 1, 2);
-    assert_width!("\u{2780}", 1, 2);
+    #[cfg(not(feature = "terminal"))]
+    {
+        assert_width!("\u{24EA}", 1, 2);
+        assert_width!("\u{2616}", 1, 2);
+        assert_width!("\u{2780}", 1, 2);
+    }
+    // With the `terminal` feature, Enclosed Alphanumerics and Dingbat
+    // circled digits are 2 columns even in non-CJK contexts, matching
+    // what terminal emulators paint. Other ambiguous characters (e.g.
+    // WHITE SHOGI PIECE U+2616) are unaffected.
+    #[cfg(feature = "terminal")]
+    {
+        assert_width!("\u{24EA}", 2, 2);
+        assert_width!("\u{2616}", 1, 2);
+        assert_width!("\u{2780}", 2, 2);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add an opt-in `terminal` feature that reports Enclosed Alphanumerics (U+2460–U+24FF), Dingbat Circled Digits (U+2776–U+2793), and Circled Numbers on Black Square (U+3248–U+324F) as **2 columns even in non-CJK contexts**.

These characters have East Asian Width "Ambiguous", so the default `width()` correctly returns 1 (UAX #11 non-CJK recommendation). However, **terminal emulators** (Windows Terminal, iTerm2, GNOME Terminal, kitty, …) render them at double width regardless of locale — their font metrics make them wide glyphs. For TUI consumers that do their own cell accounting (e.g. ratatui, and text editors built on it), the mismatch between `width()`'s 1 and the terminal's painted 2 columns shifts every downstream cell by one, causing dropped glyphs and phantom spaces.

This PR does **not** change the default behavior — `width()` keeps returning 1 for Ambiguous characters unless the consumer explicitly opts in. This preserves the crate's strict UAX #11 semantics and every existing test.

## Changes

- **`Cargo.toml`**: add `terminal = []` feature (not in default).
- **`src/lookup.rs`**: in `lookup_width_generic`, when the `terminal` feature is enabled, return 2 for the three character ranges above before consulting the width tables. The override is scoped to exactly those ranges — box-drawing glyphs (U+2500), ellipsis (U+2026), arrows, and other Ambiguous characters are unaffected.
- **`tests/tests.rs`**: extend `ambiguous_line_break` with a `#[cfg(feature = "terminal")]` branch asserting the three covered ranges report 2, while a non-covered Ambiguous character (U+2616 WHITE SHOGI PIECE) stays at 1.

## Why a feature flag instead of changing the default?

UAX #11 explicitly leaves Ambiguous width to context ("the context cannot be reliably determined"). Changing `width()`'s default to 2 for these ranges would break consumers that rely on the non-CJK convention (the existing `ambiguous_line_break` test codifies it). A feature flag lets terminal-oriented consumers opt in to terminal-emulator reality without altering the crate's contract for everyone else.

## Usage

```toml
unicode-width = { version = "0.2", features = ["terminal"] }
```

Cargo's feature unification means the flag also applies to any crate in the same dependency graph that shares the `unicode-width` build — which is exactly what TUI frameworks need, since their cell layout happens in their own (and their renderer's) width calls.

## Verification

- `cargo test` (default features) → 36 unit + 2 doctests pass; `ambiguous_line_break` unchanged.
- `cargo test --features terminal` → 36 unit + 2 doctests pass; the new branch asserts covered ranges are 2 and non-covered Ambiguous stays 1.
- `cargo test --features "terminal cjk"` → passes (flag composes with `cjk`).
- `cargo check --no-default-features` and `--no-default-features --features terminal` → pass (feature is self-contained, no new deps).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tests

## Testing

- [x] `cargo test` (default) — 36 + 2 pass
- [x] `cargo test --features terminal` — 36 + 2 pass
- [x] `cargo test --features "terminal cjk"` — pass
- [x] `cargo check --no-default-features` / `--no-default-features --features terminal` — pass
- [x] `cargo fmt --all -- --check`

## Checklist

- [x] Updated docs or comments as needed (feature documented in `Cargo.toml` and `lookup.rs`)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

## Related Issues

Reported from the CodeWhale TUI project: circled digits and keycap sequences render one column off in CJK terminals because ratatui measures them through `width()` while the terminal paints 2 columns. This feature provides the opt-in primitive for that fix (see Hmbown/CodeWhale#4479 for the original report).

## Notice
🤖 Desc generated by DeepSeek